### PR TITLE
Refac/dam

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,7 @@ import useDropDown from '../hooks/useDropDown';
 import useScrHeader from '../hooks/useScrollHeader';
 import useViewport from '../hooks/useViewport';
 import { setAuth } from '../redux/reducer/authSlice';
+import { setCartStatus } from '../redux/reducer/cartSlice';
 import { useAppDispatch, useAppSelector } from '../redux/store';
 import * as t from '../style/header.style';
 import GlobalModal from './common/GlobalModal';
@@ -22,12 +23,16 @@ export default function Header() {
   const { isHeaderVisible } = useScrHeader();
   const { isDropped, dropRef, handleRemove } = useDropDown();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
-  const cartStatus = localStorage.getItem('cartStatus');
   const isAuth = useAppSelector(state => state.authSlice.isAuth);
+  const cartNo = useAppSelector(state => state.cartSlice.cartStatus);
 
   useEffect(() => {
     const token = localStorage.getItem('token');
-    if (token) dispatch(setAuth({ isAuth: true }));
+    const cartStatus = localStorage.getItem('cartStatus');
+    if (token) {
+      dispatch(setAuth({ isAuth: true }));
+      dispatch(setCartStatus(Number(cartStatus)));
+    }
   }, []);
 
   const handleLogout = () => {
@@ -77,7 +82,7 @@ export default function Header() {
                     className="cartIcon"
                     onClick={routeToCart}
                   />
-                  <t.Badge>{cartStatus ? cartStatus : 0}</t.Badge>
+                  <t.Badge>{cartNo ? cartNo : 0}</t.Badge>
                 </t.CartStatus>
               </>
             ) : (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,6 +7,8 @@ import { HEADCATEGORY } from '../constants';
 import useDropDown from '../hooks/useDropDown';
 import useScrHeader from '../hooks/useScrollHeader';
 import useViewport from '../hooks/useViewport';
+import { setAuth } from '../redux/reducer/authSlice';
+import { useAppDispatch, useAppSelector } from '../redux/store';
 import * as t from '../style/header.style';
 import GlobalModal from './common/GlobalModal';
 import MenuDrop from './common/MenuDrop';
@@ -16,22 +18,21 @@ import SearchBar from './SearchBar';
 export default function Header() {
   const viewport = useViewport();
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
   const { isHeaderVisible } = useScrHeader();
   const { isDropped, dropRef, handleRemove } = useDropDown();
-  const [isLogin, setIsLogin] = useState<boolean>(false);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const cartStatus = localStorage.getItem('cartStatus');
+  const isAuth = useAppSelector(state => state.authSlice.isAuth);
 
   useEffect(() => {
     const token = localStorage.getItem('token');
-    if (token) {
-      setIsLogin(true);
-    } else setIsLogin(false);
-  }, [isLogin]);
+    if (token) dispatch(setAuth({ isAuth: true }));
+  }, []);
 
   const handleLogout = () => {
     localStorage.clear();
-    window.location.reload();
+    dispatch(setAuth({ isAuth: false }));
   };
   const routeToMain = () => navigate('/');
   const routeToMy = () => navigate('/mypage');
@@ -67,7 +68,7 @@ export default function Header() {
           </t.LeftSection>
           <t.RightSection>
             {!isHeaderVisible ? <SearchBar /> : null}
-            {isLogin ? (
+            {isAuth ? (
               <>
                 <p onClick={handleLogout}>로그아웃</p>
                 <HiOutlineUser className="userIcon" onClick={routeToMy} />

--- a/src/components/HeaderAside.tsx
+++ b/src/components/HeaderAside.tsx
@@ -37,7 +37,7 @@ export default function HeaderAside() {
               <div>
                 {token ? (
                   <ProfileImage
-                    image={userInfo?.u_Img && userInfo?.u_Img}
+                    image={userInfo?.u_Img && userInfo.u_Img}
                     name={userInfo?.u_Name && userInfo.u_Name}
                     id={userInfo?.u_Id && userInfo.u_Id}
                     onClick={() => setIsModalOpen(!isModalOpen)}

--- a/src/components/MyUserInfoModal.tsx
+++ b/src/components/MyUserInfoModal.tsx
@@ -59,6 +59,7 @@ export default function MyUserInfoModal({ onClose }: TProps) {
           u_Phone: formData.u_Phone,
         };
         localStorage.setItem('userInfo', JSON.stringify(editUserData));
+        onClose();
       },
       onError: error => {
         const errMsg = error.response.data.errorMessage;

--- a/src/components/detail/DetailInfo.tsx
+++ b/src/components/detail/DetailInfo.tsx
@@ -5,7 +5,8 @@ import Badge from '../../elements/Badge';
 import Button from '../../elements/Button';
 import Heart from '../../elements/Heart';
 import usePutCartQuery from '../../query/usePutCartQuery';
-import { useAppSelector } from '../../redux/store';
+import { setCartStatus } from '../../redux/reducer/cartSlice';
+import { useAppDispatch, useAppSelector } from '../../redux/store';
 import theme from '../../shared/style/theme';
 import type { IProductDetail } from '../../shared/types/types';
 import * as t from '../../style/detailInfo.style';
@@ -54,7 +55,7 @@ function DetailInfo({ product, keyNo, isLike }: TProps) {
       });
     }
   };
-
+  const dispatch = useAppDispatch();
   const cartData = {
     type: 'c',
     productNo: Number(productNo),
@@ -71,6 +72,7 @@ function DetailInfo({ product, keyNo, isLike }: TProps) {
           const acc = localStorage.getItem('cartStatus');
           const cur = Number(acc) + 1;
           localStorage.setItem('cartStatus', String(cur));
+          dispatch(setCartStatus(cur));
           setOpen(true);
         },
       });

--- a/src/components/payment/PaymentAddDefault.tsx
+++ b/src/components/payment/PaymentAddDefault.tsx
@@ -3,11 +3,7 @@ import { shallowEqual } from 'react-redux';
 import Button from '../../elements/Button';
 import ErrMsg from '../../elements/ErrorMsg';
 import Input from '../../elements/Input';
-import {
-  setName,
-  setPayInfo,
-  setPhone,
-} from '../../redux/reducer/payInputSlice';
+import { setPayInfo, setUserInfo } from '../../redux/reducer/payInputSlice';
 import { useAppDispatch, useAppSelector } from '../../redux/store';
 import theme from '../../shared/style/theme';
 import { PayInputInitial } from '../../shared/utils/inputInitialValue';
@@ -23,8 +19,8 @@ export default function PaymentAddDefault(isTabOpen: TProps) {
   const dispatch = useAppDispatch();
   const payInfo = useAppSelector(state => state.payInputSlice, shallowEqual);
   const user = JSON.parse(localStorage.getItem('userInfo'));
-  const [state, setDispatch] = useReducer(PayReducer, PayInputInitial);
-  const { name, phone } = state;
+  const [states, setDispatch] = useReducer(PayReducer, PayInputInitial);
+  const { name, phone } = states;
   const [resetUser, setResetUser] = useState<TUser>();
   const [isResetUser, setIsResetUser] = useState<boolean>(false);
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -38,13 +34,14 @@ export default function PaymentAddDefault(isTabOpen: TProps) {
     setIsResetUser(!isResetUser);
     if (!resetUser.d_Name && !resetUser.d_Phone) setDispatch({ type: 'reset' });
     else {
-      dispatch(setName(resetUser?.d_Name));
-      dispatch(setPhone(resetUser?.d_Phone));
+      dispatch(
+        setUserInfo({ d_Name: resetUser?.d_Name, d_Phone: resetUser?.d_Phone })
+      );
     }
   };
 
   useEffect(() => {
-    if (!state) return;
+    if (!states) return;
     setResetUser({
       d_Name: name.val,
       d_Phone: phone.val,

--- a/src/components/payment/PaymentAddNew.tsx
+++ b/src/components/payment/PaymentAddNew.tsx
@@ -4,15 +4,7 @@ import { shallowEqual } from 'react-redux';
 import Button from '../../elements/Button';
 import ErrMsg from '../../elements/ErrorMsg';
 import Input from '../../elements/Input';
-import {
-  setAddress1,
-  setAddress2,
-  setAddress3,
-  setDNumber,
-  setName,
-  setPayInfo,
-  setPhone,
-} from '../../redux/reducer/payInputSlice';
+import { setPayInfo } from '../../redux/reducer/payInputSlice';
 import { useAppDispatch, useAppSelector } from '../../redux/store';
 import theme from '../../shared/style/theme';
 import { PayInputInitial } from '../../shared/utils/inputInitialValue';
@@ -48,12 +40,17 @@ export default function PaymentAddNew(isTabOpen: IProps) {
   const handleClick = () => {
     if (!newUser.d_Name && !newUser.d_Phone) setDispatch({ type: 'reset' });
     else if (zipcode && address && extraAddress) {
-      dispatch(setName(newUser?.d_Name));
-      dispatch(setPhone(newUser?.d_Phone));
-      dispatch(setDNumber(0));
-      dispatch(setAddress1(zipcode));
-      dispatch(setAddress2(address));
-      dispatch(setAddress3(extraAddress));
+      dispatch(
+        setPayInfo({
+          d_Name: newUser.d_Name,
+          d_Phone: newUser.d_Phone,
+          d_No: 0,
+          d_Address1: zipcode,
+          d_Address2: address,
+          d_Address3: extraAddress,
+          d_Memo: memo && memo,
+        })
+      );
       setAllChecked(true);
     } else toast.error('입력칸을 모두 채워주세요!');
   };

--- a/src/components/payment/PaymentInput.tsx
+++ b/src/components/payment/PaymentInput.tsx
@@ -42,16 +42,17 @@ export default function PaymentInput({
 
   const handleCheck = (checked: boolean, item: TAddressList) => {
     if (checked) {
-      const data = {
-        d_No: item.d_No,
-        d_Name: item.d_Name,
-        d_Phone: item.d_Phone,
-        d_Address1: item.d_Address1,
-        d_Address2: item.d_Address2,
-        d_Address3: item.d_Address3,
-        d_Memo: drop && drop,
-      };
-      dispatch(setPayInfo(data));
+      dispatch(
+        setPayInfo({
+          d_No: item.d_No,
+          d_Name: item.d_Name,
+          d_Phone: item.d_Phone,
+          d_Address1: item.d_Address1,
+          d_Address2: item.d_Address2,
+          d_Address3: item.d_Address3,
+          d_Memo: drop && drop,
+        })
+      );
     }
   };
 

--- a/src/elements/ProfileImage.tsx
+++ b/src/elements/ProfileImage.tsx
@@ -13,7 +13,7 @@ export default function ProfileImage(props: IProps) {
   return (
     <t.Container>
       <t.UserImg
-        src={props.image ? props.image : '/assets/defaultImage.webp'}
+        src={props.image !== 'null' ? props.image : '/assets/defaultImage.webp'}
         alt={props.name}
         {...props}
       />

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -5,7 +5,7 @@ import CartItem from '../components/cart/CartItem';
 import Button from '../elements/Button';
 import useViewport from '../hooks/useViewport';
 import useCart from '../query/useCart';
-import { setCheckedList } from '../redux/reducer/cartSlice';
+import { setCartStatus, setCheckedList } from '../redux/reducer/cartSlice';
 import { useAppDispatch, useAppSelector } from '../redux/store';
 import theme from '../shared/style/theme';
 import * as t from '../style/cartPage.style';
@@ -14,10 +14,9 @@ export default function CartPage() {
   const viewport = useViewport();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+  const { cartList } = useCart();
   const [allChecked, setAllChecked] = useState<boolean>(false);
   const checkedItem = useAppSelector(state => state.cartSlice.checkedList);
-
-  const { cartList } = useCart();
 
   const handleCheck = () => {
     setAllChecked(!allChecked);
@@ -42,11 +41,10 @@ export default function CartPage() {
     removeCartItem.mutate(data, {
       onSuccess: () => {
         toast.success('상품을 삭제하였습니다.');
+        const cur = cartList.length - checkedItem.length;
+        localStorage.setItem('cartStatus', String(cur));
+        dispatch(setCartStatus(cur));
         dispatch(setCheckedList([]));
-        localStorage.setItem(
-          'cartStatus',
-          String(cartList.length - checkedItem.length)
-        );
       },
     });
   };

--- a/src/pages/PaymentPage.tsx
+++ b/src/pages/PaymentPage.tsx
@@ -10,12 +10,15 @@ import { PAYMENTINFO } from '../constants';
 import Button from '../elements/Button';
 import Input from '../elements/Input';
 import usePayment from '../query/usePayment';
+import { setCartStatus } from '../redux/reducer/cartSlice';
 import { setPayInfo } from '../redux/reducer/payInputSlice';
 import { useAppDispatch, useAppSelector } from '../redux/store';
 import theme from '../shared/style/theme';
 import * as t from '../style/paymentPage.style';
 
 export default function PaymentPage() {
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
   const payInfo = useAppSelector(state => state.payInputSlice, shallowEqual);
   const [drop, setDrop] = useState<string>('');
   const [isCheck, setIsCheck] = useState<boolean>(false);
@@ -27,9 +30,6 @@ export default function PaymentPage() {
     productNo
   );
 
-  const cartStatus = localStorage.getItem('cartStatus');
-  const currStatus = Number(cartStatus) - products?.length;
-  const navigate = useNavigate();
   const { postPay } = usePayment();
   const handleBuy = () => {
     if (!payInfo.d_Name && !payInfo.d_Phone)
@@ -49,14 +49,25 @@ export default function PaymentPage() {
       postPay.mutate(data, {
         onSuccess: () => {
           toast.success('상품 구매에 성공하였습니다 😊');
-          localStorage.setItem('cartStatus', String(currStatus));
-          navigate('/complete', { state: { price: `${price}` } });
+          const cartStatus = localStorage.getItem('cartStatus');
+          const cur = Number(cartStatus) - products?.length;
+          if (cur >= 0) {
+            localStorage.setItem('cartStatus', String(cur));
+            navigate('/complete', {
+              state: { price: `${price}` },
+            });
+            dispatch(setCartStatus(cur));
+          } else {
+            dispatch(setCartStatus(0));
+            navigate('/complete', {
+              state: { price: `${price}` },
+            });
+          }
         },
       });
     }
   };
 
-  const dispatch = useAppDispatch();
   useEffect(() => {
     dispatch(
       setPayInfo({

--- a/src/pages/ProtectedRoute.tsx
+++ b/src/pages/ProtectedRoute.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect } from 'react';
+import { Navigate } from 'react-router-dom';
+import { setAuth } from '../redux/reducer/authSlice';
+import { useAppDispatch, useAppSelector } from '../redux/store';
+
+interface IProps {
+  children: React.ReactNode;
+}
+
+export default function ProtectedRoute({ children }: IProps) {
+  const dispatch = useAppDispatch();
+  const isAuth = useAppSelector(state => state.authSlice.isAuth);
+  const token = localStorage.getItem('token');
+
+  useEffect(() => {
+    if (!isAuth && token) {
+      dispatch(setAuth({ isAuth: true }));
+    } else return;
+  }, []);
+
+  if (!isAuth) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/src/query/useAuth.ts
+++ b/src/query/useAuth.ts
@@ -45,7 +45,7 @@ const useAuth = (idData?: ISearchIdData, pwdData?: TSearchPwdData) => {
   const searchId = useQuery<
     AxiosResponse<IIdSearchResponse>,
     AxiosError<TError>
-  >([queryKeys.FINDID], () => getId(idData.u_Name, idData.u_Phone), {
+  >([queryKeys.FINDID, idData], () => getId(idData.u_Name, idData.u_Phone), {
     enabled: false,
     retry: 0,
   });
@@ -54,7 +54,7 @@ const useAuth = (idData?: ISearchIdData, pwdData?: TSearchPwdData) => {
     AxiosResponse<IPwdSearchResponse>,
     AxiosError<TError>
   >(
-    [queryKeys.FINDPWD],
+    [queryKeys.FINDPWD, pwdData],
     () => getPwd(pwdData.u_Id, pwdData.u_Name, pwdData.u_Phone),
     {
       enabled: false,

--- a/src/query/usePayment.ts
+++ b/src/query/usePayment.ts
@@ -27,9 +27,9 @@ const usePayment = (type?: string, p_No?: number) => {
   const queryClient = useQueryClient();
 
   const { data: payData } = useQuery<AxiosResponse<IPaymentResponse>, Error>(
-    [queryKeys.PAYMENT],
+    [queryKeys.PAYMENT, type, p_No],
     () => getPayment(type, p_No),
-    { refetchOnWindowFocus: false }
+    { enabled: !!type, refetchOnWindowFocus: false }
   );
   const { userInfo, addressList, products, price } = useMemo(
     () => ({

--- a/src/query/usePayment.ts
+++ b/src/query/usePayment.ts
@@ -44,7 +44,7 @@ const usePayment = (type?: string, p_No?: number) => {
   const { data: completeData } = useQuery<
     AxiosResponse<ICompleteResponse>,
     Error
-  >([queryKeys.COMPLETE], () => getComplete(), { refetchOnWindowFocus: false });
+  >([queryKeys.COMPLETE], () => getComplete());
   const { completeInfo } = useMemo(
     () => ({
       completeInfo: completeData?.data,

--- a/src/redux/reducer/authSlice.ts
+++ b/src/redux/reducer/authSlice.ts
@@ -1,0 +1,22 @@
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+
+export type TAuth = {
+  isAuth: boolean;
+};
+const initialState: TAuth = {
+  isAuth: false,
+};
+
+const authSlice = createSlice({
+  name: 'authSlice',
+  initialState,
+  reducers: {
+    setAuth: (state, action: PayloadAction<TAuth>) => {
+      return (state = action.payload);
+    },
+  },
+});
+
+export const { setAuth } = authSlice.actions;
+export default authSlice.reducer;

--- a/src/redux/reducer/cartSlice.ts
+++ b/src/redux/reducer/cartSlice.ts
@@ -10,6 +10,7 @@ type TCart = {
   checkedList: TCartList[];
   productNo: number;
   keywordNo: number;
+  cartStatus: number;
 };
 
 const initialState: TCart = {
@@ -21,6 +22,7 @@ const initialState: TCart = {
   ],
   productNo: 0,
   keywordNo: null,
+  cartStatus: 0,
 };
 
 const cartSlice = createSlice({
@@ -36,8 +38,12 @@ const cartSlice = createSlice({
     setKeywordNo: (state, action: PayloadAction<number>) => {
       state.keywordNo = action.payload;
     },
+    setCartStatus: (state, action: PayloadAction<number>) => {
+      state.cartStatus = action.payload;
+    },
   },
 });
 
-export const { setCheckedList, setProductNo, setKeywordNo } = cartSlice.actions;
+export const { setCheckedList, setProductNo, setKeywordNo, setCartStatus } =
+  cartSlice.actions;
 export default cartSlice.reducer;

--- a/src/redux/reducer/payInputSlice.ts
+++ b/src/redux/reducer/payInputSlice.ts
@@ -10,6 +10,10 @@ export type TPaymentInfo = {
   d_Address3: string;
   d_Memo?: string;
 };
+type TUserInfo = {
+  d_Name: string;
+  d_Phone: string;
+};
 const initialState: TPaymentInfo = {
   d_No: null,
   d_Name: '',
@@ -25,25 +29,17 @@ const payInputSlice = createSlice({
   initialState,
   reducers: {
     setPayInfo: (state, action: PayloadAction<TPaymentInfo>) => {
-      return (state = action.payload);
+      state.d_Name = action.payload.d_Name;
+      state.d_Phone = action.payload.d_Phone;
+      state.d_No = action.payload.d_No;
+      state.d_Address1 = action.payload.d_Address1;
+      state.d_Address2 = action.payload.d_Address2;
+      state.d_Address3 = action.payload.d_Address3;
+      state.d_Memo = action.payload.d_Memo;
     },
-    setName: (state, action: PayloadAction<string>) => {
-      state.d_Name = action.payload;
-    },
-    setPhone: (state, action: PayloadAction<string>) => {
-      state.d_Phone = action.payload;
-    },
-    setDNumber: (state, action: PayloadAction<number>) => {
-      state.d_No = action.payload;
-    },
-    setAddress1: (state, action: PayloadAction<string>) => {
-      state.d_Address1 = action.payload;
-    },
-    setAddress2: (state, action: PayloadAction<string>) => {
-      state.d_Address2 = action.payload;
-    },
-    setAddress3: (state, action: PayloadAction<string>) => {
-      state.d_Address3 = action.payload;
+    setUserInfo: (state, action: PayloadAction<TUserInfo>) => {
+      state.d_Name = action.payload.d_Name;
+      state.d_Phone = action.payload.d_Phone;
     },
     setMemo: (state, action: PayloadAction<string>) => {
       state.d_Memo = action.payload;
@@ -51,14 +47,5 @@ const payInputSlice = createSlice({
   },
 });
 
-export const {
-  setPayInfo,
-  setName,
-  setPhone,
-  setDNumber,
-  setAddress1,
-  setAddress2,
-  setAddress3,
-  setMemo,
-} = payInputSlice.actions;
+export const { setPayInfo, setUserInfo, setMemo } = payInputSlice.actions;
 export default payInputSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import type { TypedUseSelectorHook } from 'react-redux';
 import { useDispatch, useSelector } from 'react-redux';
+import authSlice from './reducer/authSlice';
 import cartSlice from './reducer/cartSlice';
 import optionSlice from './reducer/optionSlice';
 import payInputSlice from './reducer/payInputSlice';
@@ -12,6 +13,7 @@ const store = configureStore({
     payInputSlice: payInputSlice,
     cartSlice: cartSlice,
     reviewSlice: reviewSlice,
+    authSlice: authSlice,
   },
 });
 

--- a/src/shared/utils/RouteList.tsx
+++ b/src/shared/utils/RouteList.tsx
@@ -1,0 +1,145 @@
+import MyLayout from '../../components/common/MyLayout';
+import CartPage from '../../pages/CartPage';
+import CompletePage from '../../pages/CompletePage';
+import DetailPage from '../../pages/DetailPage';
+import ListPage from '../../pages/ListPage';
+import LogInPage from '../../pages/LogInPage';
+import MainPage from '../../pages/MainPage';
+import MyCancelPage from '../../pages/MyCancelPage';
+import MyOrderDetailPage from '../../pages/MyOrderDetailPage';
+import MyOrderPage from '../../pages/MyOrderPage';
+import MyWishPage from '../../pages/MyWishPage';
+import NotFoundPage from '../../pages/NotFoundPage';
+import PaymentPage from '../../pages/PaymentPage';
+import SearchPage from '../../pages/SearchPage';
+import SignUpPage from '../../pages/SignUpPage';
+
+interface RouterBase {
+  id: number;
+  path?: string;
+  index?: boolean;
+  element?: React.ReactNode;
+  withAuth?: boolean;
+}
+interface NestedRouterBase {
+  id: number;
+  path?: string;
+  element?: React.ReactNode;
+  children?: RouterBase[];
+}
+
+export const routerData: RouterBase[] = [
+  {
+    id: 0,
+    path: '/',
+    element: <MainPage />,
+    withAuth: false,
+  },
+  {
+    id: 1,
+    path: '/list/:category',
+    element: <ListPage />,
+    withAuth: false,
+  },
+  {
+    id: 2,
+    path: '/search/:keyword',
+    element: <SearchPage />,
+    withAuth: false,
+  },
+  {
+    id: 3,
+    path: '/detail/:productNo',
+    element: <DetailPage />,
+    withAuth: false,
+  },
+  {
+    id: 4,
+    path: 'login',
+    element: <LogInPage />,
+    withAuth: false,
+  },
+  {
+    id: 5,
+    path: 'signup',
+    element: <SignUpPage />,
+    withAuth: false,
+  },
+  {
+    id: 6,
+    element: <MyLayout />,
+    withAuth: true,
+  },
+  {
+    id: 7,
+    path: 'cart',
+    element: <CartPage />,
+    withAuth: true,
+  },
+  {
+    id: 8,
+    path: 'payment',
+    element: <PaymentPage />,
+    withAuth: true,
+  },
+  {
+    id: 9,
+    path: 'complete',
+    element: <CompletePage />,
+    withAuth: true,
+  },
+  {
+    id: 10,
+    path: '*',
+    element: <NotFoundPage />,
+    withAuth: false,
+  },
+];
+
+export const myRouteData: NestedRouterBase[] = [
+  {
+    id: 0,
+    path: 'mypage',
+    children: [
+      {
+        id: 0,
+        index: true,
+        element: <MyOrderPage />,
+      },
+      {
+        id: 1,
+        path: ':id',
+        index: false,
+        element: <MyOrderDetailPage />,
+      },
+      {
+        id: 2,
+        path: 'cancel-call/:id',
+        index: false,
+        element: <MyCancelPage />,
+      },
+    ],
+  },
+  {
+    id: 1,
+    path: 'wish',
+    element: <MyWishPage />,
+  },
+  {
+    id: 2,
+    path: 'cancel',
+    children: [
+      {
+        id: 0,
+        index: true,
+        element: <MyOrderPage />,
+      },
+      {
+        id: 1,
+        path: ':id',
+        index: false,
+        element: <MyOrderDetailPage />,
+      },
+    ],
+  },
+];

--- a/src/shared/utils/Router.tsx
+++ b/src/shared/utils/Router.tsx
@@ -4,6 +4,7 @@ import {
   Outlet,
   Route,
 } from 'react-router-dom';
+import styled from 'styled-components';
 import Footer from '../../components/Footer';
 import Header from '../../components/Header';
 import ProtectedRoute from '../../pages/ProtectedRoute';
@@ -61,8 +62,14 @@ function Layout() {
   return (
     <>
       <Header />
-      <Outlet />
+      <Container>
+        <Outlet />
+      </Container>
       <Footer />
     </>
   );
 }
+
+const Container = styled.div`
+  min-height: 850px;
+`;

--- a/src/shared/utils/Router.tsx
+++ b/src/shared/utils/Router.tsx
@@ -4,54 +4,57 @@ import {
   Outlet,
   Route,
 } from 'react-router-dom';
-import MyLayout from '../../components/common/MyLayout';
 import Footer from '../../components/Footer';
 import Header from '../../components/Header';
-import CartPage from '../../pages/CartPage';
-import CompletePage from '../../pages/CompletePage';
-import DetailPage from '../../pages/DetailPage';
-import ListPage from '../../pages/ListPage';
-import LogInPage from '../../pages/LogInPage';
-import MainPage from '../../pages/MainPage';
-import MyCancelPage from '../../pages/MyCancelPage';
-import MyOrderDetailPage from '../../pages/MyOrderDetailPage';
-import MyOrderPage from '../../pages/MyOrderPage';
-import MyWishPage from '../../pages/MyWishPage';
-import NotFoundPage from '../../pages/NotFoundPage';
-import PaymentPage from '../../pages/PaymentPage';
-import SearchPage from '../../pages/SearchPage';
-import SignUpPage from '../../pages/SignUpPage';
+import ProtectedRoute from '../../pages/ProtectedRoute';
+import { myRouteData, routerData } from './RouteList';
 
 const Router = createBrowserRouter(
   createRoutesFromElements(
-    <>
-      <Route path="/" element={<Layout />}>
-        <Route index element={<MainPage />} />
-        <Route path="/list/:category" element={<ListPage />} />
-        <Route path="/search/:keyword" element={<SearchPage />} />
-        <Route path="/detail/:productNo" element={<DetailPage />} />
-        <Route path="login" element={<LogInPage />} />
-        <Route path="signup" element={<SignUpPage />} />
-        <Route element={<MyLayout />}>
-          <Route path="mypage">
-            <Route index element={<MyOrderPage />} />
-            <Route path=":id" element={<MyOrderDetailPage />} />
-            <Route path="cancel-call/:id" element={<MyCancelPage />} />
-          </Route>
-          <Route path="wish" element={<MyWishPage />} />
-          <Route path="cancel">
-            <Route index element={<MyOrderPage />} />
-            <Route path=":id" element={<MyOrderDetailPage />} />
-          </Route>
-        </Route>
-        <Route path="cart" element={<CartPage />} />
-        <Route path="payment" element={<PaymentPage />} />
-        <Route path="complete" element={<CompletePage />} />
-        <Route path="*" element={<NotFoundPage />} />
-      </Route>
-    </>
+    <Route path="/" element={<Layout />}>
+      {routerData.map(router => {
+        if (router.withAuth) {
+          return (
+            <Route
+              key={router.id}
+              path={router.path}
+              element={<ProtectedRoute>{router.element}</ProtectedRoute>}
+            >
+              {myRouteData.map(myRouter => {
+                return (
+                  <Route
+                    key={myRouter.id}
+                    path={myRouter.path}
+                    element={myRouter.element}
+                  >
+                    {myRouter.children &&
+                      myRouter.children.map(item => (
+                        <Route
+                          index={item.index}
+                          key={item.id}
+                          path={item.path}
+                          element={item.element}
+                        />
+                      ))}
+                  </Route>
+                );
+              })}
+            </Route>
+          );
+        } else {
+          return (
+            <Route
+              key={router.id}
+              path={router.path}
+              element={router.element}
+            />
+          );
+        }
+      })}
+    </Route>
   )
 );
+
 export default Router;
 
 function Layout() {

--- a/src/style/paymentInput.style.ts
+++ b/src/style/paymentInput.style.ts
@@ -39,7 +39,7 @@ export const ShipList = styled.div`
   width: 100%;
   display: flex;
   align-items: flex-start;
-  gap: 20px;
+  gap: 10px;
   padding: 20px 5px 20px 5px;
   border-bottom: 1px solid ${({ theme }) => theme.ls10};
   input {
@@ -54,6 +54,7 @@ export const ShipList = styled.div`
     color: ${({ theme }) => theme.fc08};
     font-size: ${({ theme }) => theme.fs16};
     line-height: ${({ theme }) => theme.fs24};
+    min-width: 30px;
     cursor: pointer;
   }
   label {


### PR DESCRIPTION
- #27 
- [x] get 요청시 쿼리키, 쿼리옵션 추가
- #30 
- [x] 기존 라우터의 import 컴포넌트 정보를 객체 배열로 만들어 RouteList 컴포넌트로 분리
- [x] Auth 접근 권한에 따른 라우팅 처리를 위해 기존 라우터 수정
- [x] Auth 권한이 필요한 페이지를 ProtectedRoute의 자식 컴포넌트로 수정
- [x] Auth 권한은 localstorage token과 redux의 authSlice로 전역 관리